### PR TITLE
A user only has access to it's own IssueSubmissions

### DIFF
--- a/erudit/editor/models.py
+++ b/erudit/editor/models.py
@@ -3,6 +3,8 @@ from django.utils.translation import gettext as _
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 
+from erudit.models import Publisher
+
 
 class IssueSubmission(models.Model):
     """ A journal issue submission by an editor """
@@ -57,6 +59,22 @@ class IssueSubmission(models.Model):
     def get_absolute_url(self):
         """ Return the absolute URL for this model """
         return reverse('editor:update', kwargs={'pk': self.pk})
+
+    def has_access(self, user):
+        """ Determine if the user has access to this IssueSubmission
+
+        A user has access to an IssueSubmission if it is a member of the
+        publisher of the journal.
+        """
+        if not user:
+            return False
+
+        return bool(
+            Publisher.objects.filter(
+                journals=self.journal,
+                members=user
+            ).count()
+        )
 
     class Meta:
         verbose_name = _("Envoi de numéro")

--- a/erudit/editor/views.py
+++ b/erudit/editor/views.py
@@ -4,8 +4,8 @@ from django.views.generic.edit import CreateView, UpdateView
 from django.views.generic import ListView
 
 from django.contrib.auth.decorators import login_required
-
 from django.core.urlresolvers import reverse
+from django.http import HttpResponseRedirect
 
 from erudit.models import Journal, Publisher
 from editor.models import IssueSubmission
@@ -60,6 +60,12 @@ class IssueSubmissionUpdate(LoginRequiredMixin, UpdateView):
     model = IssueSubmission
     form_class = IssueSubmissionUploadForm
     template_name = 'form.html'
+
+    def dispatch(self, request, *args, **kwargs):
+        submission = IssueSubmission.objects.get(pk=kwargs['pk'])
+        if not submission.has_access(request.user):
+            return HttpResponseRedirect(reverse('editor:dashboard'))
+        return super().dispatch(request, *args, **kwargs)
 
     def get_success_url(self):
         return reverse('editor:dashboard')

--- a/erudit/erudit/tests.py
+++ b/erudit/erudit/tests.py
@@ -14,15 +14,38 @@ class BaseEruditTestCase(TestCase):
             password='top_secret'
         )
 
+        self.other_user = User.objects.create_user(
+            username='testuser',
+            email='testuser@erudit.org',
+            password='top_secret'
+        )
+
         self.publisher = Publisher.objects.create(
             name='Éditeur de test',
         )
 
+        # Add a publisher
         self.publisher.members.add(self.user)
         self.publisher.save()
 
+        self.other_publisher = Publisher.objects.create(
+            name='Autre éditeur de test',
+        )
+
+        # Add a second publisher
+        self.other_publisher.members.add(self.other_user)
+        self.other_publisher.save()
+
+        # Add a journal
         self.journal = Journal.objects.create(
             code='test',
             name='Revue de test',
             publisher=self.publisher,
+        )
+
+        # Add a second journal
+        self.other_journal = Journal.objects.create(
+            code='test',
+            name='Autre revue de test',
+            publisher=self.other_publisher,
         )


### PR DESCRIPTION
A user will only have access to an IssueSubmission if it has been made for a journal published by a publisher it is associated with. This commit introduces a `BaseEditorTestCase` class creates two journals and publishers. `BaseEditorTestCase` serve as the basis for all Editor tests. 