### PR TITLE
Breadcrumbs

### DIFF
--- a/erudit/editor/templates/base_editor.html
+++ b/erudit/editor/templates/base_editor.html
@@ -40,3 +40,17 @@
   </ul>
 </nav>
 {% endblock %}
+
+{% block content %}
+<main class="main">
+  <header>
+    <h1>
+      <span class="user-space">{% block zone-title %}Espace éditeurs{% endblock %}</span> {% block page-title %}{% endblock %}
+    </h1>
+  </header>
+  <div class="container-fluid">
+    {% block content-main %}
+    {% endblock %}
+  </div>
+</main>
+{% endblock %}

--- a/erudit/editor/templates/base_editor.html
+++ b/erudit/editor/templates/base_editor.html
@@ -47,6 +47,8 @@
     <h1>
       <span class="user-space">{% block zone-title %}Espace éditeurs{% endblock %}</span> {% block page-title %}{% endblock %}
     </h1>
+  </header>
+  <div class="container-fluid">
     <div class="breadcrumbs">
       {% block breadcrumbs %}
       {% url 'editor:dashboard' as dashboard %}
@@ -55,8 +57,6 @@
       {% endif %}
       {% endblock %}
     </div>
-  </header>
-  <div class="container-fluid">
     {% block content-main %}
     {% endblock %}
   </div>

--- a/erudit/editor/templates/base_editor.html
+++ b/erudit/editor/templates/base_editor.html
@@ -27,7 +27,7 @@
 <nav class="sidenav">
   <ul>
     <li>
-      <a href="{% url 'editor:issues' %}" {% url 'editor:issues' as add_url %}{% if request.get_full_path == add_url %}class="active"{% endif %}>
+      <a href="{% url 'editor:issues' %}" {% url 'editor:issues' as issues %}{% if request.get_full_path == issues %}class="active"{% endif %}>
         <span class="icon glyphicon glyphicon-upload"></span> <span class="sidenav-label">Dépôt de numéros</span>
       </a>
     </li>
@@ -48,7 +48,12 @@
       <span class="user-space">{% block zone-title %}Espace éditeurs{% endblock %}</span> {% block page-title %}{% endblock %}
     </h1>
     <div class="breadcrumbs">
-      {% block breadcrumbs %}Espace éditeurs » Tableau de bord{% endblock %}
+      {% block breadcrumbs %}
+      {% url 'editor:dashboard' as dashboard %}
+      {% if request.get_full_path != dashboard %}
+      <a href="{% url 'editor:dashboard' %}">Tableau de bord</a>
+      {% endif %}
+      {% endblock %}
     </div>
   </header>
   <div class="container-fluid">

--- a/erudit/editor/templates/base_editor.html
+++ b/erudit/editor/templates/base_editor.html
@@ -27,8 +27,8 @@
 <nav class="sidenav">
   <ul>
     <li>
-      <a href="{% url 'editor:add' %}" {% url 'editor:add' as add_url %}{% if request.get_full_path == add_url %}class="active"{% endif %}>
-        <span class="icon glyphicon glyphicon-upload"></span> <span class="sidenav-label">Fichiers de production</span>
+      <a href="{% url 'editor:issues' %}" {% url 'editor:issues' as add_url %}{% if request.get_full_path == add_url %}class="active"{% endif %}>
+        <span class="icon glyphicon glyphicon-upload"></span> <span class="sidenav-label">Dépôt de numéros</span>
       </a>
     </li>
     <li><a href="#" class="disabled"><span class="icon icon-epub"></span> <span class="sidenav-label">Dépôt EPUB</span></a></li>
@@ -47,6 +47,9 @@
     <h1>
       <span class="user-space">{% block zone-title %}Espace éditeurs{% endblock %}</span> {% block page-title %}{% endblock %}
     </h1>
+    <div class="breadcrumbs">
+      {% block breadcrumbs %}Espace éditeurs » Tableau de bord{% endblock %}
+    </div>
   </header>
   <div class="container-fluid">
     {% block content-main %}

--- a/erudit/editor/templates/dashboard.html
+++ b/erudit/editor/templates/dashboard.html
@@ -1,77 +1,70 @@
 {% extends "base_editor.html" %}
 {% load i18n staticfiles %}
 
-{% block pagetitle %}
-Tableau de bord | Espace éditeurs | Érudit
+{% block page-title %}
+Tableau de bord
 {% endblock %}
 
-{% block content %}
-<main class="main">
-  <header>
-    <h1><span class="user-space">Espace éditeur</span> Tableau de bord</h1>
-  </header>
-  <div class="container-fluid">
-    <div class="col-sm-6 col-xs-12">
-      <section class="card card-issue_submissions">
-        <h2>Votre compte</h2>
-        <h3>Prénom Nom</h3>
-        <ul>
-          <li>Transmission des fichiers de production</li>
-          <li><a href="mailto:">courriel@courriel.ca</a></li>
-        </ul>
-        <h3><a href="#" target="_blank">Nom de la revue</a></h3>
-        <ul>
-          <li>Revue savante</li>
-          <li>Direction / rédaction&nbsp;: Prénom Nom, <a href="mailto:">courriel@courriel.ca</a></li>
-          <li>Éditeur&nbsp;: Nom de l'éditeur</li>
-          <li>ISSN&nbsp;: 1234-1234 (imprimé) 1234-1234 (numérique)</li>
-        </ul>
-        <h3><a href="#" target="_blank">Nom de la revue</a></h3>
-        <ul>
-          <li>Revue culturelle</li>
-          <li>Direction / rédaction&nbsp;: Prénom Nom, <a href="mailto:">courriel@courriel.ca</a></li>
-          <li>Éditeur&nbsp;: Nom de l'éditeur</li>
-          <li>ISSN&nbsp;: 1234-1234 (imprimé) 1234-1234 (numérique)</li>
-        </ul>
-      </section>
+{% block content-main %}
+<div class="col-sm-6 col-xs-12">
+  <section class="card card-issue_submissions">
+    <h2>Votre compte</h2>
+    <h3>Prénom Nom</h3>
+    <ul>
+      <li>Transmission des fichiers de production</li>
+      <li><a href="mailto:">courriel@courriel.ca</a></li>
+    </ul>
+    <h3><a href="#" target="_blank">Nom de la revue</a></h3>
+    <ul>
+      <li>Revue savante</li>
+      <li>Direction / rédaction&nbsp;: Prénom Nom, <a href="mailto:">courriel@courriel.ca</a></li>
+      <li>Éditeur&nbsp;: Nom de l'éditeur</li>
+      <li>ISSN&nbsp;: 1234-1234 (imprimé) 1234-1234 (numérique)</li>
+    </ul>
+    <h3><a href="#" target="_blank">Nom de la revue</a></h3>
+    <ul>
+      <li>Revue culturelle</li>
+      <li>Direction / rédaction&nbsp;: Prénom Nom, <a href="mailto:">courriel@courriel.ca</a></li>
+      <li>Éditeur&nbsp;: Nom de l'éditeur</li>
+      <li>ISSN&nbsp;: 1234-1234 (imprimé) 1234-1234 (numérique)</li>
+    </ul>
+  </section>
+</div>
+<div class="col-sm-6 col-xs-12">
+  <section class="card card-issue_submissions">
+    <h2>Historique du dépôt de fichiers</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Revue</th>
+          <th>Date</th>
+          <th>Année, volumaison, numéro</th>
+          <th>Statut</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for issue_submission in object_list|dictsortreversed:"date_created"|slice:":5" %}
+        <tr>
+          {% ifchanged %}
+          <td>{{ issue_submission.journal }}</td>
+          {% else %}
+          <td></td>
+          {% endifchanged %}
+          <td>{{ issue_submission.date_created|date:"c" }}</td>
+          <td><a href="{% url 'editor:update' issue_submission.pk %}">{{ issue_submission.year }}, volume {{ issue_submission.volume }}, numéro {{ issue_submission.number }}</a></td>
+          <td><span class="glyphicon glyphicon-ok"></span></td>
+        </tr>
+        {% empty %}
+        <tr>
+          <td colspan="3" class="text-center">Il n'y a aucun fichier dans votre historique.</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+      <caption>Cinq derniers fichiers déposés</caption>
+    </table>
+    <div class="text-right more-info">
+      <button class="btn btn-primary btn-add"><a href="{% url 'editor:add' %}"><span class="icon glyphicon glyphicon-plus"></span></a></button>
     </div>
-    <div class="col-sm-6 col-xs-12">
-      <section class="card card-issue_submissions">
-        <h2>Historique du dépôt de fichiers</h2>
-        <table>
-          <thead>
-            <tr>
-              <th>Revue</th>
-              <th>Date</th>
-              <th>Année, volumaison, numéro</th>
-              <th>Statut</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for issue_submission in object_list|dictsortreversed:"date_created"|slice:":5" %}
-            <tr>
-              {% ifchanged %}
-              <td>{{ issue_submission.journal }}</td>
-              {% else %}
-              <td></td>
-              {% endifchanged %}
-              <td>{{ issue_submission.date_created|date:"c" }}</td>
-              <td><a href="{% url 'editor:update' issue_submission.pk %}">{{ issue_submission.year }}, volume {{ issue_submission.volume }}, numéro {{ issue_submission.number }}</a></td>
-              <td><span class="glyphicon glyphicon-ok"></span></td>
-            </tr>
-            {% empty %}
-            <tr>
-              <td colspan="3" class="text-center">Il n'y a aucun fichier dans votre historique.</td>
-            </tr>
-            {% endfor %}
-          </tbody>
-          <caption>Cinq derniers fichiers déposés</caption>
-        </table>
-        <div class="text-right more-info">
-          <button class="btn btn-primary btn-add"><a href="{% url 'editor:add' %}"><span class="icon glyphicon glyphicon-plus"></span></a></button>
-        </div>
-      </section>
-    </div>
-  </div>
-</main>
+  </section>
+</div>
 {% endblock %}

--- a/erudit/editor/templates/form.html
+++ b/erudit/editor/templates/form.html
@@ -1,8 +1,8 @@
 {% extends "base_editor.html" %}
 {% load i18n staticfiles %}
 
-{% block pagetitle %}
-Fichiers de production | Espace éditeurs | Érudit
+{% block page-title %}
+Fichiers de production
 {% endblock %}
 
 {% block extrahead %}
@@ -10,6 +10,7 @@ Fichiers de production | Espace éditeurs | Érudit
 {% endblock %}
 
 {% load crispy_forms_tags %}
+<<<<<<< HEAD
 {% block content %}
 <main class="main">
   <header>
@@ -63,4 +64,52 @@ Fichiers de production | Espace éditeurs | Érudit
     </div>
   </div>
 </main>
+=======
+{% block content-main %}
+<div class="col-md-6 col-md-offset-3 col-xs-12">
+  <section class="card card-upload_form">
+    <h2>Déposer des fichiers de production</h2>
+    <form class="form-vertical" method="post">
+      {% csrf_token %}
+      {% if form.errors %}
+      <div class="col-xs-12">
+        <p class="alert alert-warning">Veuillez remplir les champs obligatoires.</p>
+      </div>
+      {% endif %}
+      <div class="form-group col-xs-12 {% if form.journal.errors %}error{% endif %}">
+        {{ form.journal.label_tag }}
+        {{ form.journal }}
+      </div>
+      <div class="form-group col-xs-4 {% if form.year.errors %}error{% endif %}">
+        {{ form.year.label_tag }}
+        {{ form.year }}
+      </div>
+      <div class="form-group col-xs-4 {% if form.volume.errors %}error{% endif %}">
+        {{ form.volume.label_tag }}
+        {{ form.volume }}
+      </div>
+      <div class="form-group col-xs-4 {% if form.number.errors %}error{% endif %}">
+        {{ form.number.label_tag }}
+        {{ form.number }}
+      </div>
+      <div class="form-group col-xs-12">
+        {{ form.contact.label_tag }}
+        {{ form.contact }}
+      </div>
+      <div class="form-group col-xs-12">
+        {{ form.comment.label_tag }}
+        {{ form.comment }}
+      </div>
+      <div class="form-group col-xs-12 {% if form.submission_file.errors %}error{% endif %}">
+        {{ form.submission_file.label_tag }}
+        {{ form.submission_file }}
+      </div>
+      <div class="form-group">
+        <button type="submit" class="btn btn-primary" id="submit-id-submit">Enregistrer</button>
+        <button type="reset" class="btn" id="submit-id-reset">Annuler</button>
+      </div>
+    </form>
+  </section>
+</div>
+>>>>>>> 6fa78a7... simplify blocks and reduce repeated markup in templates
 {% endblock %}

--- a/erudit/editor/templates/form.html
+++ b/erudit/editor/templates/form.html
@@ -14,61 +14,6 @@ Ajout d'un numéro
 {% endblock %}
 
 {% load crispy_forms_tags %}
-<<<<<<< HEAD
-{% block content %}
-<main class="main">
-  <header>
-    <h1><span class="user-space">Espace éditeur</span> Fichiers de production</h1>
-  </header>
-  <div class="container-fluid">
-    <div class="col-md-6 col-md-offset-3 col-xs-12">
-      <section class="card card-upload_form">
-        <h2>Déposer des fichiers de production</h2>
-        <form class="form-vertical" method="post">
-          {% csrf_token %}
-          {% if form.errors %}
-          <div class="col-xs-12">
-            <p class="alert alert-warning">Veuillez remplir les champs obligatoires.</p>
-          </div>
-          {% endif %}
-          <div class="form-group col-xs-12 {% if form.journal.errors %}error{% endif %}">
-            {{ form.journal.label_tag }}
-            {{ form.journal }}
-          </div>
-          <div class="form-group col-xs-4 {% if form.year.errors %}error{% endif %}">
-            {{ form.year.label_tag }}
-            {{ form.year }}
-          </div>
-          <div class="form-group col-xs-4 {% if form.volume.errors %}error{% endif %}">
-            {{ form.volume.label_tag }}
-            {{ form.volume }}
-          </div>
-          <div class="form-group col-xs-4 {% if form.number.errors %}error{% endif %}">
-            {{ form.number.label_tag }}
-            {{ form.number }}
-          </div>
-          <div class="form-group col-xs-12 {% if form.contact.errors %}error{% endif %}">
-            {{ form.contact.label_tag }}
-            {{ form.contact }}
-          </div>
-          <div class="form-group col-xs-12">
-            {{ form.comment.label_tag }}
-            {{ form.comment }}
-          </div>
-          <div class="form-group col-xs-12 {% if form.submission_file.errors %}error{% endif %}">
-            {{ form.submission_file.label_tag }}
-            {{ form.submission_file }}
-          </div>
-          <div class="form-group">
-            <button type="submit" class="btn btn-primary" id="submit-id-submit">Enregistrer</button>
-            <button type="reset" class="btn" id="submit-id-reset">Annuler</button>
-          </div>
-        </form>
-      </section>
-    </div>
-  </div>
-</main>
-=======
 {% block content-main %}
 <div class="col-md-6 col-md-offset-3 col-xs-12">
   <section class="card card-upload_form">
@@ -115,5 +60,4 @@ Ajout d'un numéro
     </form>
   </section>
 </div>
->>>>>>> 6fa78a7... simplify blocks and reduce repeated markup in templates
 {% endblock %}

--- a/erudit/editor/templates/form.html
+++ b/erudit/editor/templates/form.html
@@ -2,11 +2,11 @@
 {% load i18n staticfiles %}
 
 {% block page-title %}
-Dépôt de numéros
+Ajout d'un numéro
 {% endblock %}
 
 {% block breadcrumbs %}
-    <a href="{% url 'editor:dashboard' %}">{{ block.super }}</a> » <a href="{% url 'editor:issues' %}">Dépôt de numéros</a> » Ajout de numéros
+  {{ block.super }} / <a href="{% url 'editor:issues' %}">Dépôt de numéros</a> / Ajout d'un numéro
 {% endblock %}
 
 {% block extrahead %}

--- a/erudit/editor/templates/form.html
+++ b/erudit/editor/templates/form.html
@@ -2,7 +2,11 @@
 {% load i18n staticfiles %}
 
 {% block page-title %}
-Fichiers de production
+Dépôt de numéros
+{% endblock %}
+
+{% block breadcrumbs %}
+    <a href="{% url 'editor:dashboard' %}">{{ block.super }}</a> » <a href="{% url 'editor:issues' %}">Dépôt de numéros</a> » Ajout de numéros
 {% endblock %}
 
 {% block extrahead %}

--- a/erudit/editor/templates/issues.html
+++ b/erudit/editor/templates/issues.html
@@ -6,7 +6,7 @@ Dépôt de numéros
 {% endblock %}
 
 {% block breadcrumbs %}
-    <a href="{% url 'editor:dashboard' %}">{{ block.super }}</a> » Dépôt de numéros
+    {{ block.super }} / Dépôt de numéros
 {% endblock %}
 
 {% block content-main %}

--- a/erudit/editor/templates/issues.html
+++ b/erudit/editor/templates/issues.html
@@ -2,35 +2,15 @@
 {% load i18n staticfiles %}
 
 {% block page-title %}
-Tableau de bord
+Dépôt de numéros
+{% endblock %}
+
+{% block breadcrumbs %}
+    <a href="{% url 'editor:dashboard' %}">{{ block.super }}</a> » Dépôt de numéros
 {% endblock %}
 
 {% block content-main %}
-<div class="col-sm-6 col-xs-12">
-  <section class="card card-issue_submissions">
-    <h2>Votre compte</h2>
-    <h3>Prénom Nom</h3>
-    <ul>
-      <li>Transmission des fichiers de production</li>
-      <li><a href="mailto:">courriel@courriel.ca</a></li>
-    </ul>
-    <h3><a href="#" target="_blank">Nom de la revue</a></h3>
-    <ul>
-      <li>Revue savante</li>
-      <li>Direction / rédaction&nbsp;: Prénom Nom, <a href="mailto:">courriel@courriel.ca</a></li>
-      <li>Éditeur&nbsp;: Nom de l'éditeur</li>
-      <li>ISSN&nbsp;: 1234-1234 (imprimé) 1234-1234 (numérique)</li>
-    </ul>
-    <h3><a href="#" target="_blank">Nom de la revue</a></h3>
-    <ul>
-      <li>Revue culturelle</li>
-      <li>Direction / rédaction&nbsp;: Prénom Nom, <a href="mailto:">courriel@courriel.ca</a></li>
-      <li>Éditeur&nbsp;: Nom de l'éditeur</li>
-      <li>ISSN&nbsp;: 1234-1234 (imprimé) 1234-1234 (numérique)</li>
-    </ul>
-  </section>
-</div>
-<div class="col-sm-6 col-xs-12">
+<div class="col-sm-6 col-sm-offset-3 col-xs-12">
   <section class="card card-issue_submissions">
     <h2>Historique du dépôt de numéros</h2>
     <table>
@@ -43,7 +23,7 @@ Tableau de bord
         </tr>
       </thead>
       <tbody>
-        {% for issue_submission in object_list|dictsortreversed:"date_created"|slice:":3" %}
+        {% for issue_submission in object_list|dictsortreversed:"date_created" %}
         <tr>
           {% ifchanged %}
           <td>{{ issue_submission.journal }}</td>
@@ -60,7 +40,6 @@ Tableau de bord
         </tr>
         {% endfor %}
       </tbody>
-      <caption>Trois derniers fichiers déposés (<a href="{% url 'editor:issues' %}">Voir l'historique complet</a>)</caption>
     </table>
     <div class="text-right more-info">
       <button class="btn btn-primary btn-add"><a href="{% url 'editor:add' %}"><span class="icon glyphicon glyphicon-plus"></span></a></button>

--- a/erudit/editor/urls.py
+++ b/erudit/editor/urls.py
@@ -1,8 +1,14 @@
 from django.conf.urls import url
 
-from editor.views import IssueSubmissionCreate, IssueSubmissionUpdate, DashboardView
+from editor.views import (
+    IssueSubmissionCreate,
+    IssueSubmissionUpdate,
+    DashboardView,
+    IssueSubmissionList
+)
 
 urlpatterns = [
+    url(r'^numero/$', IssueSubmissionList.as_view(), name='issues'),
     url(r'^numero/ajout', IssueSubmissionCreate.as_view(), name='add'),
     url(r'^numero/(?P<pk>[0-9]+)/$', IssueSubmissionUpdate.as_view(), name='update'),
     url(r'', DashboardView.as_view(), name='dashboard')

--- a/erudit/editor/views.py
+++ b/erudit/editor/views.py
@@ -69,3 +69,20 @@ class IssueSubmissionUpdate(LoginRequiredMixin, UpdateView):
 
     def get_success_url(self):
         return reverse('editor:dashboard')
+
+
+class IssueSubmissionList(LoginRequiredMixin, ListView):
+
+    template_name = 'issues.html'
+
+    def get_queryset(self):
+
+        publishers = Publisher.objects.filter(
+            members=self.request.user
+        )
+
+        return IssueSubmission.objects.filter(
+            journal__publisher=publishers
+        ).order_by(
+            'journal__publisher'
+        )

--- a/erudit/erudit/static/sass/base/_typography.scss
+++ b/erudit/erudit/static/sass/base/_typography.scss
@@ -9,7 +9,7 @@ body {
   -webkit-font-smoothing: antialiased;
   font-weight: 400;
   font-size: 16px;
-  color: $colour-dark-grey;
+  color: #161919;
 }
 
 h1, h2, h3, h4, h5, h6 {

--- a/erudit/erudit/static/sass/components/_breadcrumbs.scss
+++ b/erudit/erudit/static/sass/components/_breadcrumbs.scss
@@ -1,5 +1,10 @@
 .breadcrumbs {
-  display: table-cell;
-  vertical-align: middle;
-  text-align: right;
+  margin-top: 1.5em;
+  font-size: 0.85em;
+  a {
+    color: rgba(0, 0, 0, 0.5);
+    &:hover, &:focus, &:active, &:active:focus {
+      text-decoration: none;
+    }
+  }
 }

--- a/erudit/erudit/static/sass/components/_breadcrumbs.scss
+++ b/erudit/erudit/static/sass/components/_breadcrumbs.scss
@@ -1,0 +1,5 @@
+.breadcrumbs {
+  display: table-cell;
+  vertical-align: middle;
+  text-align: right;
+}

--- a/erudit/erudit/static/sass/components/_forms.scss
+++ b/erudit/erudit/static/sass/components/_forms.scss
@@ -387,7 +387,7 @@ label:not(.required):after {
   font-size: 0.85em;
 }
 .error {
-  input {
+  input, .select2 {
     border-color: $colour-warning;
     background-color: rgba($colour-warning, 0.15);
   }

--- a/erudit/erudit/static/sass/main.scss
+++ b/erudit/erudit/static/sass/main.scss
@@ -27,6 +27,7 @@
   'components/forms',
   'components/dropdowns',
   'components/alerts',
+  'components/breadcrumbs',
   'components/fileupload';
 
   // Page-specific styles

--- a/erudit/erudit/static/sass/pages/_login.scss
+++ b/erudit/erudit/static/sass/pages/_login.scss
@@ -1,4 +1,5 @@
 .login-page {
+  padding-left: 0;
   a {
     font-size: 0.85em;
   }

--- a/erudit/erudit/templates/base.html
+++ b/erudit/erudit/templates/base.html
@@ -10,7 +10,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <title>{% block pagetitle %}{% endblock %}</title>
+    <title>{% block page-title %}{% endblock %} | {% block zone-title %}{% endblock %} | Érudit</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="application-name" content="Espace administratif | Érudit"/>

--- a/erudit/erudit/templates/registration/login.html
+++ b/erudit/erudit/templates/registration/login.html
@@ -1,53 +1,59 @@
 {% extends "base.html" %}
 {% load i18n staticfiles %}
 
-{% block pagetitle %}
-Espace éditeur | Érudit
+{% block page-title %}
+Connexion
+{% endblock %}
+
+{% block zone-title %}
+Espace éditeurs
 {% endblock %}
 
 {% block content %}
-<div class="container-fluid login-page">
-  <div class="row">
-    <div class="col-lg-4 col-lg-offset-4 col-sm-6 col-sm-offset-3 col-xs-12">
-      <section class="card card-login">
-        <div class="erudit-logo">
-          <a href="http://erudit.org/" target="_blank">
-            <img src="{% static 'img/logo-erudit.png' %}" class="img-responsive"/>
-          </a>
-        </div>
-        <form class="form-vertical" method="post">
-          {% csrf_token %}
-          {% if form.non_field_errors %}
-          <div class="col-xs-12">
-            {% for error in form.non_field_errors %}
-            <p class="alert alert-warning">{{ error }}</p>
-            {% endfor %}
+<main class="login-page">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-lg-4 col-lg-offset-4 col-sm-6 col-sm-offset-3 col-xs-12">
+        <section class="card card-login">
+          <div class="erudit-logo">
+            <a href="http://erudit.org/" target="_blank">
+              <img src="{% static 'img/logo-erudit.png' %}" class="img-responsive"/>
+            </a>
           </div>
-          {% endif %}
-          <div class="form-group">
-            <label for="id_username">Nom d'utilisateur</label>
-            {{ form.username }}
-            <div class="alert alert-error-text">{{ form.username.errors.as_text }}</div>
-          </div>
-          <div class="form-group">
-            <label for="id_password">Mot de passe</label>
-            {{ form.password }}
-            <div class="alert alert-error-text">{{ form.password.errors.as_text }}</div>
-          </div>
-          <div class="form-group">
-            <div class="text-right">
-              <a href="{% url 'password_reset' %}">Mot de passe oublié&nbsp;?</a>
+          <form class="form-vertical" method="post">
+            {% csrf_token %}
+            {% if form.non_field_errors %}
+            <div class="col-xs-12">
+              {% for error in form.non_field_errors %}
+              <p class="alert alert-warning">{{ error }}</p>
+              {% endfor %}
             </div>
-          </div>
-          <div class="form-group text-center">
-            <button type="submit" class="btn btn-primary" id="submit-id-submit">Connexion</button>
-          </div>
-          <p class="card-footer">
-            <a href="http://erudit.org/" target="_blank"><small>erudit.org</small></a>
-          </p>
-        </form>
-      </section>
+            {% endif %}
+            <div class="form-group">
+              <label for="id_username">Nom d'utilisateur</label>
+              {{ form.username }}
+              <div class="alert alert-error-text">{{ form.username.errors.as_text }}</div>
+            </div>
+            <div class="form-group">
+              <label for="id_password">Mot de passe</label>
+              {{ form.password }}
+              <div class="alert alert-error-text">{{ form.password.errors.as_text }}</div>
+            </div>
+            <div class="form-group">
+              <div class="text-right">
+                <a href="{% url 'password_reset' %}">Mot de passe oublié&nbsp;?</a>
+              </div>
+            </div>
+            <div class="form-group text-center">
+              <button type="submit" class="btn btn-primary" id="submit-id-submit">Connexion</button>
+            </div>
+            <p class="card-footer">
+              <a href="http://erudit.org/" target="_blank"><small>erudit.org</small></a>
+            </p>
+          </form>
+        </section>
+      </div>
     </div>
   </div>
-</div>
+</main>
 {% endblock %}


### PR DESCRIPTION
Cleaning up the templates to remove repeated blocks of markup. Adding a simple breadcrumb in templates for clear navigation, and an additional page with a detailed history of all the issues that were submitted. 

This is the page that is accessed from the lateral menu. It is an intermediary step between the dashboard and a new submission (dashboard => detailed view of submissions => new submission). It will also eventually allow a more concise dashboard view of the issue submission history.